### PR TITLE
Show error details on contact form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
+        "@types/firebase": "^2.4.32",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.2.17",
         "@vitejs/plugin-react": "^4.2.1",
@@ -1874,6 +1875,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/firebase": {
+      "version": "2.4.32",
+      "resolved": "https://registry.npmjs.org/@types/firebase/-/firebase-2.4.32.tgz",
+      "integrity": "sha512-WHuDkJq4PjH3HzmogWstX/r+/c0dGFq7F1fZ9LgT/B4zh/0fps0fUxLDNtuSJZ+PLIpm/EALBhcqZr0qtEy85g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@types/firebase": "^2.4.32",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^4.2.1",

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -18,6 +18,9 @@ const ContactForm = ({ systems, onClose }: ContactFormProps) => {
   const [selectedSystemId, setSelectedSystemId] = useState<string>('')
   const [newSystemName, setNewSystemName] = useState('')
 
+  // Store any error messages so we can surface them in the UI for easier debugging
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
   const isCreatingNewSystem = selectedSystemId === 'NEW_SYSTEM'
 
   // Contact types
@@ -45,7 +48,10 @@ const ContactForm = ({ systems, onClose }: ContactFormProps) => {
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    if (!user) return
+    if (!user) {
+      setErrorMessage('You need to be logged in to save a contact.')
+      return
+    }
 
     let systemId = selectedSystemId
 
@@ -81,6 +87,12 @@ const ContactForm = ({ systems, onClose }: ContactFormProps) => {
       onClose()
     } catch (err) {
       console.error('Error saving contact', err)
+      // Show the error to the user so they know what went wrong
+      if (err instanceof Error) {
+        setErrorMessage(err.message)
+      } else {
+        setErrorMessage(String(err))
+      }
     }
   }
 
@@ -88,6 +100,13 @@ const ContactForm = ({ systems, onClose }: ContactFormProps) => {
     <div className="fixed inset-0 z-40 bg-black bg-opacity-60 flex items-center justify-center backdrop-blur-sm">
       <form onSubmit={handleSubmit} className="bg-gray-800 w-96 p-6 rounded-lg border border-gray-700 space-y-4">
         <h2 className="text-xl font-semibold text-white mb-2">Add New Contact</h2>
+
+        {/* Display any error that occurred while trying to save */}
+        {errorMessage && (
+          <div className="bg-red-900 text-red-300 px-3 py-2 rounded-md border border-red-700 text-sm">
+            {errorMessage}
+          </div>
+        )}
 
         <div>
           <label className="block text-sm text-gray-300 mb-1">Name *</label>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from 'react'
+import React, { useState, type FormEvent } from 'react'
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore'
 import { db } from '../firebase'
 import { SystemData } from '../hooks/useSystems'

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, type FormEvent } from 'react'
+import { useState, type FormEvent } from 'react'
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore'
 import { db } from '../firebase'
 import { SystemData } from '../hooks/useSystems'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "jsxImportSource": "react",
     "types": ["react", "react-dom"],
 
     /* Linting */

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,6 +758,11 @@
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
+"@types/firebase@^2.4.32":
+  version "2.4.32"
+  resolved "https://registry.npmjs.org/@types/firebase/-/firebase-2.4.32.tgz"
+  integrity sha512-WHuDkJq4PjH3HzmogWstX/r+/c0dGFq7F1fZ9LgT/B4zh/0fps0fUxLDNtuSJZ+PLIpm/EALBhcqZr0qtEy85g==
+
 "@types/node@^18.0.0 || >=20.0.0", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
   version "24.0.10"
   resolved "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz"


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Display contact form save errors on the frontend and resolve associated TypeScript errors.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR introduces a new state variable to capture and display error messages directly within the contact form modal if saving fails or the user is not logged in. This provides immediate user feedback instead of silent console logging. To address TypeScript errors introduced by these changes, `@types/firebase` was installed, `tsconfig.json` was updated to include `"jsxImportSource": "react"`, and the redundant `import React from 'react'` was removed, ensuring proper compilation with the new JSX transform.